### PR TITLE
Scaffold Next.js portfolio with Tailwind and TypeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+/node_modules
+/.next
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+.DS_Store
+.env
+
+# Typescript
+*.tsbuildinfo
+
+# Mac/VS
+.idea
+.vscode

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# AGENTS
+
+## Testing
+- Run `npm config set registry https://registry.npmjs.org/` to ensure the default NPM registry is used.
+- Run `npm install` to install dependencies.
+- Run `npm test` to lint the codebase.
+- Run `npm run build` to ensure the project compiles.
+

--- a/app/(site)/contact/page.tsx
+++ b/app/(site)/contact/page.tsx
@@ -1,0 +1,8 @@
+export default function ContactPage() {
+  return (
+    <div className="container-narrow">
+      <h1 className="mb-4 text-2xl font-semibold">Contact</h1>
+      <p className="text-sm text-ink-200">Écris-moi à <a href="mailto:you@example.com">you@example.com</a> ou via LinkedIn.</p>
+    </div>
+  );
+}

--- a/app/(site)/ecrits/page.tsx
+++ b/app/(site)/ecrits/page.tsx
@@ -1,0 +1,18 @@
+import posts from "@/data/posts.json";
+import Link from "next/link";
+
+export default function EcritsPage() {
+  return (
+    <div className="container-narrow">
+      <h1 className="mb-4 text-2xl font-semibold">Écrits</h1>
+      <ul className="space-y-3">
+        {posts.map((p) => (
+          <li key={p.title} className="rounded-2xl border border-ink-800 bg-ink-900/40 p-4">
+            <div className="text-sm">{p.type === "curation" ? "Curation" : "Article"} — <Link href={p.url} className="text-mustard underline">{p.title}</Link></div>
+            {p.summary && <p className="text-xs text-ink-300 mt-1">{p.summary}</p>}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/(site)/expertise/page.tsx
+++ b/app/(site)/expertise/page.tsx
@@ -1,0 +1,21 @@
+import skills from "@/data/skills.json";
+
+export default function ExpertisePage() {
+  return (
+    <div className="container-narrow">
+      <h1 className="mb-4 text-2xl font-semibold">Expertise</h1>
+      <ul className="space-y-3">
+        {skills.map((s) => (
+          <li key={s.name} className="rounded-2xl border border-ink-800 bg-ink-900/40 p-4">
+            <div className="flex items-center justify-between">
+              <strong>{s.name}</strong>
+              <span className="text-sm text-ink-300">Niveau {s.level}/5</span>
+            </div>
+            {s.proof && <p className="text-sm text-ink-200 mt-1">Preuves : {s.proof}</p>}
+            {s.next && <p className="text-xs text-ink-400 mt-1">Prochain palier : {s.next}</p>}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import "@/styles/globals.css";
+import "@/styles/tokens.css";
+import Header from "@/components/layout/Header";
+import Footer from "@/components/layout/Footer";
+
+export const metadata: Metadata = {
+  title: "—Souphiane Jender - Portfolio",
+  description: "Ingénieur pédagogique & dev web — projets, expertise, méthodo."
+};
+
+export default function SiteLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="fr">
+      <body className="bg-ink-950 text-ink-50">
+        <Header />
+        <main className="container-wide py-8">{children}</main>
+        <Footer />
+      </body>
+    </html>
+  );
+}

--- a/app/(site)/mes-projets/page.tsx
+++ b/app/(site)/mes-projets/page.tsx
@@ -1,0 +1,22 @@
+import projects from "@/data/projects.json";
+import Link from "next/link";
+import Card from "@/components/ui/Card";
+
+export default function MesProjetsPage() {
+  return (
+    <div className="container-narrow">
+      <h1 className="mb-4 text-2xl font-semibold">Mes projets</h1>
+      <div className="grid gap-4 md:grid-cols-2">
+        {projects.map((p) => (
+          <Card key={p.slug}>
+            <h2 className="text-lg font-semibold">{p.title}</h2>
+            <p className="text-sm text-ink-200">{p.summary}</p>
+            <div className="mt-3">
+              <Link className="text-mustard underline underline-offset-4" href={`/projet/${p.slug}`}>Étude de cas →</Link>
+            </div>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(site)/methodo/page.tsx
+++ b/app/(site)/methodo/page.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+export default function MethodoPage() {
+  return (
+    <div className="container-narrow">
+      <h1 className="mb-4 text-2xl font-semibold">Méthodo — ADDIE × Scrum × Kirkpatrick</h1>
+      <p className="text-sm text-ink-200">
+        J’itère court (Scrum), je conçois aligné (ADDIE) et je mesure (Kirkpatrick L1–L4).
+      </p>
+      <p className="mt-3">
+        <Link className="text-mustard underline underline-offset-4" href="/goodprojform">
+          Préparer une fiche projet →
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,0 +1,86 @@
+import Link from "next/link";
+import Section from "@/components/ui/Section";
+import Card from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import projects from "@/data/projects.json";
+
+export default function HomePage() {
+  const spotlight = projects.slice(0, 3);
+  return (
+    <div className="container-narrow space-y-10">
+      {/* Hero */}
+      <section aria-labelledby="hero-title" className="mt-6">
+        <h1 id="hero-title" className="text-3xl font-semibold">
+          Ingénieur pédagogique & dev web — j’aligne design, code et métriques pour des apprentissages utiles.
+        </h1>
+        <p className="mt-2 text-ink-200">Ex : -30 à -40% time-to-competency sur 3 cohortes, suivi xAPI.</p>
+        <div className="mt-4 flex gap-3">
+          <Button as="link" href="/mes-projets">Voir 3 projets vedettes</Button>
+          <Button variant="ghost" as="link" href="/contact">Me contacter</Button>
+        </div>
+      </section>
+
+      {/* Spotlight projets */}
+      <Section title="Projets vedettes" subtitle="PAR compact, accès direct aux études de cas.">
+        <div className="grid gap-4 md:grid-cols-3">
+          {spotlight.map((p) => (
+            <Card key={p.slug}>
+              <h3 className="text-lg font-semibold">{p.title}</h3>
+              {p.metric && <p className="text-sm text-mint">{p.metric}</p>}
+              <p className="mt-2 text-sm text-ink-200">{p.summary}</p>
+              <div className="mt-3">
+                <Link className="text-sm text-mustard underline underline-offset-4" href={`/projet/${p.slug}`}>
+                  Étude de cas →
+                </Link>
+              </div>
+            </Card>
+          ))}
+        </div>
+        <div className="mt-4">
+          <Button as="link" href="/mes-projets" variant="ghost">Tout voir</Button>
+        </div>
+      </Section>
+
+      {/* Proof bar */}
+      <Section title="Preuves rapides">
+        <Card>
+          <p className="text-sm">
+            « Clair, mesurable, efficace » — CSAT 4,6/5 — -40 % time-to-competency (n=86)
+          </p>
+        </Card>
+      </Section>
+
+      {/* Deux portes */}
+      <Section title="Choisir sa porte">
+        <div className="grid gap-4 md:grid-cols-2">
+          <Card>
+            <h3 className="text-lg font-semibold">Mes projets</h3>
+            <p className="text-sm text-ink-200">Onboarding, xAPI, Storyline, Next.js…</p>
+            <div className="mt-3"><Button as="link" href="/mes-projets">Explorer</Button></div>
+          </Card>
+          <Card>
+            <h3 className="text-lg font-semibold">Expertise</h3>
+            <p className="text-sm text-ink-200">Compétences rédigées : niveau → preuves → prochain palier.</p>
+            <div className="mt-3"><Button as="link" href="/expertise">Voir mes compétences</Button></div>
+          </Card>
+        </div>
+      </Section>
+
+      {/* Écrits */}
+      <Section title="Écrits récents">
+        <ul className="list-disc pl-6 text-sm">
+          <li><Link href="/ecrits">Mesurer un parcours avec xAPI</Link></li>
+          <li><Link href="/ecrits">Pourquoi ce guide Next.js m’a aidé</Link></li>
+        </ul>
+      </Section>
+
+      {/* Play */}
+      <Section title="Play">
+        <Card>
+          <p className="text-sm text-ink-200">Serious games maison. Chargement uniquement sur la page dédiée.</p>
+          <div className="mt-3"><Button as="link" href="/play">Jouer</Button></div>
+        </Card>
+      </Section>
+    </div>
+  );
+}

--- a/app/(site)/play/page.tsx
+++ b/app/(site)/play/page.tsx
@@ -1,0 +1,8 @@
+export default function PlayPage() {
+  return (
+    <div className="container-narrow">
+      <h1 className="mb-4 text-2xl font-semibold">Play</h1>
+      <p className="text-sm text-ink-200">Serious games en ligne. Le chargement des jeux se fait uniquement ici (perf).</p>
+    </div>
+  );
+}

--- a/app/(site)/projet/[slug]/page.tsx
+++ b/app/(site)/projet/[slug]/page.tsx
@@ -1,0 +1,25 @@
+import { notFound } from "next/navigation";
+import projects from "@/data/projects.json";
+
+export default function ProjetPage({ params }: { params: { slug: string } }) {
+  const project = projects.find((p) => p.slug === params.slug);
+  if (!project) return notFound();
+
+  return (
+    <div className="container-narrow">
+      <h1 className="text-2xl font-semibold">{project.title}</h1>
+      {project.metric && <p className="text-mint mt-1">{project.metric}</p>}
+      <section className="mt-6 space-y-4">
+        <h2 className="text-xl font-semibold">Contexte (P)</h2>
+        <p className="text-sm text-ink-200">Résumé du problème et baseline (à détailler step 3).</p>
+        <h2 className="text-xl font-semibold">Actions (A)</h2>
+        <ul className="list-disc pl-6 text-sm text-ink-200">
+          <li>Approche et choix clés (tech + pédago).</li>
+          <li>Itérations, accessibilité, traçabilité.</li>
+        </ul>
+        <h2 className="text-xl font-semibold">Résultats (R)</h2>
+        <p className="text-sm text-ink-200">{project.summary}</p>
+      </section>
+    </div>
+  );
+}

--- a/app/robots.txt
+++ b/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,0 +1,9 @@
+export default function Footer() {
+  return (
+    <footer className="border-t border-ink-800">
+      <div className="container-wide py-8 text-center text-xs text-ink-400">
+        © {new Date().getFullYear()} — Portfolio pédagogique & tech.
+      </div>
+    </footer>
+  );
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+
+const nav = [
+  { href: "/mes-projets", label: "Mes projets" },
+  { href: "/expertise", label: "Expertise" },
+  { href: "/methodo", label: "Méthodo" },
+  { href: "/ecrits", label: "Écrits" },
+  { href: "/play", label: "Play" },
+  { href: "/contact", label: "Contact" }
+];
+
+export default function Header() {
+  return (
+    <header className="border-b border-ink-800 bg-ink-900/50">
+      <div className="container-wide flex items-center justify-between py-4">
+        <Link href="/" className="focus-ring text-sm font-semibold">
+          GoodProj
+        </Link>
+        <nav className="flex items-center gap-4 text-sm">
+          {nav.map((n) => (
+            <Link key={n.href} href={n.href} className="focus-ring text-ink-200 hover:text-ink-50">
+              {n.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils";
+type Variant = "tech" | "pedago" | "case";
+
+export default function Badge({ label, variant = "case", className }: { label: string; variant?: Variant; className?: string }) {
+  const map = {
+    tech: "bg-mustard text-ink-950",
+    pedago: "bg-mint text-ink-950",
+    case: "bg-beige text-ink-900"
+  } as const;
+  return (
+    <span className={cn("inline-flex items-center rounded-pill border border-ink-700 px-3 py-1 text-xs font-semibold", map[variant], className)}>
+      {label}
+    </span>
+  );
+}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/lib/utils";
+import Link from "next/link";
+import type { ComponentProps } from "react";
+
+type Variant = "primary" | "ghost";
+type As = "button" | "a" | "link";
+
+interface ButtonProps extends ComponentProps<"button"> {
+  variant?: Variant;
+  as?: As;
+  href?: string;
+}
+
+export default function Button({ variant = "primary", as = "button", href, className, ...props }: ButtonProps) {
+  const base = "inline-flex items-center justify-center rounded-pill px-4 py-2 text-sm focus-ring";
+  const variants = {
+    primary: "bg-mustard text-ink-950 hover:opacity-90",
+    ghost: "bg-transparent border border-ink-700 text-ink-200 hover:bg-ink-900"
+  } as const;
+
+  const cls = cn(base, variants[variant], className);
+
+  if (as === "a" && href) return <a className={cls} href={href} {...props} />;
+  if (as === "link" && href) return <Link className={cls} href={href} {...(props as any)} />;
+  return <button className={cls} {...props} />;
+}

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,0 +1,5 @@
+import { cn } from "@/lib/utils";
+
+export default function Card({ className, children }: { className?: string; children: React.ReactNode }) {
+  return <article className={cn("rounded-2xl border border-ink-800 bg-ink-900/40 p-5", className)}>{children}</article>;
+}

--- a/components/ui/Icon.tsx
+++ b/components/ui/Icon.tsx
@@ -1,0 +1,4 @@
+export default function Icon({ name, className }: { name: string; className?: string }) {
+  // TODO step 3: remplacer par <svg><use href="/icons/retro_icons_sprite.svg#icon-{name}" /></svg>
+  return <span aria-hidden className={className}>□</span>;
+}

--- a/components/ui/Section.tsx
+++ b/components/ui/Section.tsx
@@ -1,0 +1,19 @@
+export default function Section({
+  title,
+  subtitle,
+  children
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="container-wide my-8">
+      <header className="mb-4">
+        <h2 className="text-2xl font-semibold">{title}</h2>
+        {subtitle && <p className="text-sm text-ink-300">{subtitle}</p>}
+      </header>
+      {children}
+    </section>
+  );
+}

--- a/data/posts.json
+++ b/data/posts.json
@@ -1,0 +1,4 @@
+[
+  { "title": "Mesurer un parcours avec xAPI", "type": "article", "url": "#" },
+  { "title": "Pourquoi ce guide Next.js m’a aidé", "type": "curation", "url": "#" }
+]

--- a/data/projects.json
+++ b/data/projects.json
@@ -1,0 +1,23 @@
+[
+  {
+    "slug": "onboarding-dev-40",
+    "title": "Onboarding dev — -40% time-to-competency",
+    "summary": "P: 10j pour être autonome. A: micro-modules + portail Next.js + xAPI. R: 10→6j, complétion +32pts, CSAT 4,6/5.",
+    "metric": "-40% T2C",
+    "tags": ["Tech", "Pédagogie"]
+  },
+  {
+    "slug": "lms-xapi-dashboard",
+    "title": "LMS + xAPI — dashboard d’usage",
+    "summary": "P: peu de mesure. A: xAPI (experienced/answered), LRS, dashboard BI. R: roadmap pilotée par données.",
+    "metric": "Traçabilité fine",
+    "tags": ["Tech"]
+  },
+  {
+    "slug": "storyline-micro-modules",
+    "title": "Storyline — micro-modules adaptatifs",
+    "summary": "P: parcours longs. A: scénarisation cas, quiz adaptatifs, mobile-first. R: complétion +28pts, verbatims positifs.",
+    "metric": "+28pts complétion",
+    "tags": ["Pédagogie"]
+  }
+]

--- a/data/skills.json
+++ b/data/skills.json
@@ -1,0 +1,7 @@
+[
+  { "name": "xAPI & LRS", "level": 4, "proof": "Tracking complet sur 3 modules", "next": "Corrélation L3-L4" },
+  { "name": "Next.js", "level": 4, "proof": "Portail onboarding; LCP <2s", "next": "RUM + A/B à l’échelle" },
+  { "name": "Storyline", "level": 3, "proof": "6 micro-modules, variables", "next": "Adaptatif + xAPI custom" },
+  { "name": "Scrum", "level": 4, "proof": "Sprints 1–2 sem., DoD", "next": "Metrics flow/lead-time" },
+  { "name": "Accessibilité", "level": 3, "proof": "WCAG AA de base", "next": "Audit complet + tooling" }
+]

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,23 @@
+export type Tag = "Tech" | "Pédagogie" | "Play" | string;
+
+export interface Project {
+  slug: string;
+  title: string;
+  summary: string;     // PAR compact (1–2 lignes)
+  metric?: string;     // ex. "-40% T2C"
+  tags: Tag[];
+}
+
+export interface Skill {
+  name: string;
+  level: number;       // 1..5
+  proof?: string;
+  next?: string;
+}
+
+export interface PostItem {
+  title: string;
+  type: "article" | "curation";
+  url: string;
+  summary?: string;
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue } from "clsx";
+import clsx from "clsx";
+
+export function cn(...inputs: ClassValue[]) {
+  return clsx(inputs);
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "portfolio-presentation-v2",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "npm run lint"
+  },
+  "dependencies": {
+    "clsx": "^2.1.1",
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "14.2.5",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.7",
+    "typescript": "^5.5.4"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,1 @@
+module.exports = { plugins: { tailwindcss: {}, autoprefixer: {} } };

--- a/public/icons/retro_icons_sprite.svg
+++ b/public/icons/retro_icons_sprite.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true"></svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,18 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+html, body { height: 100%; }
+body { @apply bg-ink-950 text-ink-50 antialiased; }
+
+a { @apply underline underline-offset-4 text-mint; }
+a:hover { @apply opacity-90; }
+
+.container-narrow { @apply mx-auto max-w-3xl; }
+.container-wide   { @apply mx-auto max-w-6xl; }
+
+.focus-ring { @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-mint; }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,0 +1,4 @@
+:root {
+  --ink-950:#15181d; --ink-900:#1f232a; --ink-800:#2b3038; --ink-50:#f7f7f8;
+  --mustard:#C9A227; --mint:#8AC6A6; --beige:#FAF7F1;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,33 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        ink: {
+          50: "#f7f7f8",
+          100: "#eeeff1",
+          200: "#d9dbe0",
+          300: "#b9bcc5",
+          400: "#8a90a0",
+          500: "#61697a",
+          600: "#474e5d",
+          700: "#363c48",
+          800: "#2b3038",
+          900: "#1f232a",
+          950: "#15181d"
+        },
+        mustard: "#C9A227",
+        mint: "#8AC6A6",
+        beige: "#FAF7F1"
+      },
+      borderRadius: {
+        pill: "999px"
+      },
+      container: { center: true, padding: "1rem" }
+    }
+  },
+  plugins: []
+};
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,43 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2022"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "types": [
+      "node"
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- add TypeScript base URL and `@/*` path alias for clean imports
- expose `npm test` script and document install/build steps in `AGENTS.md`
- note default npm registry config step in `AGENTS.md`

## Testing
- `npm config set registry https://registry.npmjs.org/`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/autoprefixer)*
- `npm test` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aec9c5542c832f9fcf32bf60ef8044