### PR TITLE
feat: add Word Rain game to play section

### DIFF
--- a/app/(site)/play/page.tsx
+++ b/app/(site)/play/page.tsx
@@ -1,8 +1,22 @@
+import GameCanvas from "@/components/GameCanvas";
+
 export default function PlayPage() {
   return (
-    <div className="container-narrow">
-      <h1 className="mb-4 text-2xl font-semibold">Play</h1>
-      <p className="text-sm text-ink-200">Serious games en ligne. Le chargement des jeux se fait uniquement ici (perf).</p>
-    </div>
+    <main
+      style={{
+        minHeight: "100vh",
+        display: "grid",
+        placeItems: "center",
+        background:
+          "linear-gradient(180deg, rgba(20,20,24,1) 0%, rgba(8,8,10,1) 100%)",
+        color: "white",
+        fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, Arial",
+      }}
+    >
+      <div style={{ width: "min(92vw, 960px)" }}>
+        <h1 style={{ marginBottom: 12 }}>Word Rain — mini démo</h1>
+        <GameCanvas />
+      </div>
+    </main>
   );
 }

--- a/components/GameCanvas.tsx
+++ b/components/GameCanvas.tsx
@@ -1,0 +1,215 @@
+"use client";
+import React, { useEffect, useRef, useState } from "react";
+import { drawScene } from "@/lib/render/canvas2d";
+import {
+  createInitialState,
+  update,
+  tryReset,
+  type GameState,
+  type InputEvent,
+} from "@/lib/game/logic";
+import { GAME_HEIGHT, GAME_WIDTH } from "@/lib/game/config";
+
+type HUDSnapshot = {
+  score: number;
+  lives: number;
+  buffer: string;
+  seqIndex: number;
+  targetSequence: string[];
+  status: "running" | "over";
+};
+
+export default function GameCanvas() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const ctxRef = useRef<CanvasRenderingContext2D | null>(null);
+  const stateRef = useRef<GameState>(createInitialState());
+  const inputsRef = useRef<InputEvent[]>([]);
+  const [hud, setHud] = useState<HUDSnapshot>(() => snapshot(stateRef.current));
+
+  // DPR scaling & resize
+  useEffect(() => {
+    const canvas = canvasRef.current!;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctxRef.current = ctx;
+
+    const resize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      // Fit into parent width, keep aspect ratio (GAME_WIDTH x GAME_HEIGHT)
+      const parent = canvas.parentElement!;
+      const maxW = parent.clientWidth;
+      const targetW = Math.min(maxW, GAME_WIDTH);
+      const scale = targetW / GAME_WIDTH;
+      const cssW = Math.round(GAME_WIDTH * scale);
+      const cssH = Math.round(GAME_HEIGHT * scale);
+      canvas.style.width = cssW + "px";
+      canvas.style.height = cssH + "px";
+      canvas.width = Math.round(cssW * dpr);
+      canvas.height = Math.round(cssH * dpr);
+      ctx.setTransform(dpr * scale, 0, 0, dpr * scale, 0, 0);
+      // Reset font after transform
+      ctx.font = "16px system-ui";
+      ctx.textBaseline = "top";
+    };
+    resize();
+    const ro = new ResizeObserver(resize);
+    ro.observe(canvas.parentElement!);
+    const onDpr = () => resize();
+    window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`).addEventListener?.("change", onDpr);
+    return () => {
+      ro.disconnect();
+      window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`).removeEventListener?.("change", onDpr);
+    };
+  }, []);
+
+  // Keyboard input
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const s = stateRef.current;
+      if (s.status === "over" && (e.key === "r" || e.key === "R")) {
+        stateRef.current = tryReset(s);
+        return;
+      }
+      if (s.status === "over") return;
+      if (e.key === "Backspace") {
+        inputsRef.current.push({ kind: "backspace" });
+        e.preventDefault();
+        return;
+      }
+      if (e.key === "Enter") {
+        inputsRef.current.push({ kind: "submit" });
+        return;
+      }
+      // Accept single visible characters (letters incl. accents, numbers)
+      if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        inputsRef.current.push({ kind: "char", payload: e.key });
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  // Pointer/touch selection (hit-test on words)
+  useEffect(() => {
+    const canvas = canvasRef.current!;
+    const onPointerDown = (evt: PointerEvent) => {
+      const ctx = ctxRef.current;
+      if (!ctx) return;
+      const rect = canvas.getBoundingClientRect();
+      const x = ((evt.clientX - rect.left) / rect.width) * GAME_WIDTH;
+      const y = ((evt.clientY - rect.top) / rect.height) * GAME_HEIGHT;
+      const s = stateRef.current;
+      if (s.status === "over") return;
+      // Measure and find first word whose bounding box contains (x, y)
+      // Assume ~24px height per word line box
+      const H = 24;
+      // Check top-most first: reverse by y descending
+      const words = [...s.words].sort((a, b) => b.y - a.y);
+      for (const w of words) {
+        const wWidth = ctx.measureText(w.text).width + 8; // padding
+        const hit =
+          x >= w.x &&
+          x <= w.x + wWidth &&
+          y >= w.y - 4 && // small top tolerance
+          y <= w.y + H;
+        if (hit) {
+          inputsRef.current.push({ kind: "pointerSelect", payload: { id: w.id } });
+          break;
+        }
+      }
+    };
+    canvas.addEventListener("pointerdown", onPointerDown);
+    return () => canvas.removeEventListener("pointerdown", onPointerDown);
+  }, []);
+
+  // RAF loop (fixed-step with accumulator)
+  useEffect(() => {
+    let raf = 0;
+    let last = performance.now();
+    let acc = 0;
+    const FIXED = 1000 / 60; // ~16.666ms
+
+    const tick = () => {
+      const now = performance.now();
+      let dt = now - last;
+      last = now;
+      if (dt > 50) dt = 50; // clamp
+      acc += dt;
+
+      while (acc >= FIXED) {
+        const inputs = inputsRef.current;
+        inputsRef.current = [];
+        stateRef.current = update(stateRef.current, FIXED, inputs);
+        acc -= FIXED;
+      }
+
+      const ctx = ctxRef.current;
+      if (ctx) {
+        drawScene(ctx, stateRef.current, { width: GAME_WIDTH, height: GAME_HEIGHT });
+      }
+
+      // Update HUD every frame (cheap)
+      setHud(snapshot(stateRef.current));
+
+      if (stateRef.current.status !== "over") {
+        raf = requestAnimationFrame(tick);
+      } else {
+        // Draw final frame with "Game Over" already rendered by drawScene
+      }
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  return (
+    <div>
+      <canvas
+        ref={canvasRef}
+        style={{
+          width: GAME_WIDTH,
+          height: GAME_HEIGHT,
+          background: "#0e0f14",
+          borderRadius: 12,
+          boxShadow: "0 10px 30px rgba(0,0,0,.4)",
+        }}
+      />
+      <div style={{ marginTop: 8, fontSize: 14, opacity: 0.85 }}>
+        <b>Score:</b> {hud.score} &nbsp;•&nbsp; <b>Vies:</b> {hud.lives} &nbsp;•&nbsp;{" "}
+        <b>Buffer:</b> “{hud.buffer}”
+        <div style={{ marginTop: 4 }}>
+          <b>Séquence:</b>{" "}
+          {hud.targetSequence.map((w, i) => (
+            <span
+              key={w + i}
+              style={{
+                padding: "2px 6px",
+                marginRight: 6,
+                borderRadius: 6,
+                background: i === hud.seqIndex ? "rgba(255,215,0,.25)" : "rgba(255,255,255,.08)",
+                border: i === hud.seqIndex ? "1px solid rgba(255,215,0,.6)" : "1px solid rgba(255,255,255,.12)",
+              }}
+            >
+              {w}
+            </span>
+          ))}
+        </div>
+        {hud.status === "over" && (
+          <div style={{ marginTop: 6, color: "#ffd700" }}>
+            Game Over — appuie sur <b>R</b> pour recommencer.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function snapshot(s: GameState): HUDSnapshot {
+  return {
+    score: s.score,
+    lives: s.lives,
+    buffer: s.buffer,
+    seqIndex: s.seqIndex,
+    targetSequence: s.targetSequence,
+    status: s.status,
+  };
+}

--- a/lib/game/config.ts
+++ b/lib/game/config.ts
@@ -1,0 +1,23 @@
+export const GAME_WIDTH = 800;
+export const GAME_HEIGHT = 450;
+
+// Gameplay
+export const MAX_LIVES = 3;
+export const POINTS_PER_STEP = 10; // points par bon mot (dans l'ordre)
+
+// Chute
+export const BASE_FALL_PX_PER_S = 90;
+export const FALL_SPEED_VARIANCE = 40;
+
+// Spawn
+export const SPAWN_INTERVAL_MS = 3000; // base
+export const SPAWN_JITTER_MS = 600; // +/- aléatoire
+export const GOOD_PROBABILITY = 0.6; // proba de spawn d'un mot "good"
+export const NEXT_TARGET_BIAS = 0.55; // si "good", chance de forcer le prochain mot attendu
+
+// Rendu
+export const WORD_FONT = "16px system-ui";
+export const WORD_BOX_PAD = 4;
+export const WORD_BOX_H = 24;
+export const COLOR_BG = "#0e0f14";
+export const COLOR_TEXT = "#e6e7eb";

--- a/lib/game/logic.ts
+++ b/lib/game/logic.ts
@@ -1,0 +1,216 @@
+import {
+  BASE_FALL_PX_PER_S,
+  FALL_SPEED_VARIANCE,
+  MAX_LIVES,
+  POINTS_PER_STEP,
+  SPAWN_INTERVAL_MS,
+  SPAWN_JITTER_MS,
+  GOOD_PROBABILITY,
+  NEXT_TARGET_BIAS,
+  GAME_HEIGHT,
+  GAME_WIDTH,
+} from "./config";
+import type { GameState, InputEvent, WordEntity } from "./types";
+export type { GameState, InputEvent } from "./types";
+
+// Séquence "bonne" (dans l'ordre)
+const DEFAULT_SEQUENCE = ["rouge", "vert", "bleu"];
+// Mots "faux" (distracteurs)
+const BAD_WORDS = [
+  "jaune",
+  "noir",
+  "blanc",
+  "orange",
+  "marron",
+  "rose",
+  "violet",
+  "gris",
+  "cyan",
+  "magenta",
+  "sable",
+  "olive",
+];
+
+let _id = 0;
+const newId = () => String(++_id);
+
+export function createInitialState(): GameState {
+  return {
+    timeMs: 0,
+    score: 0,
+    lives: MAX_LIVES,
+    words: [],
+    buffer: "",
+    status: "running",
+    seqIndex: 0,
+    targetSequence: [...DEFAULT_SEQUENCE],
+    lastSpawnMs: 0,
+    nextSpawnJitter: randInRange(-SPAWN_JITTER_MS, SPAWN_JITTER_MS),
+  };
+}
+
+export function tryReset(s: GameState): GameState {
+  if (s.status !== "over") return s;
+  return createInitialState();
+}
+
+// Boucle d'update (fixed-step)
+export function update(prev: GameState, dtMs: number, inputs: InputEvent[]): GameState {
+  if (prev.status === "over") return prev;
+  let s = { ...prev, timeMs: prev.timeMs + dtMs };
+
+  // Inputs clavier/pointer
+  s = applyInputs(s, inputs);
+
+  // Spawn
+  if (shouldSpawn(s)) {
+    s = spawnWord(s);
+  }
+
+  // Chute
+  const dtSec = dtMs / 1000;
+  s.words = s.words.map((w) => stepFall(w, dtSec));
+
+  // Sortie d'écran ⇒ vie perdue
+  const kept: WordEntity[] = [];
+  let lost = 0;
+  for (const w of s.words) {
+    if (w.y > GAME_HEIGHT + 16) {
+      lost++;
+    } else {
+      kept.push(w);
+    }
+  }
+  if (lost > 0) {
+    s.lives = Math.max(0, s.lives - lost);
+  }
+  s.words = kept;
+
+  if (s.lives <= 0) {
+    s.status = "over";
+  }
+  return s;
+}
+
+export function applyInputs(prev: GameState, inputs: InputEvent[]): GameState {
+  let s = { ...prev };
+  for (const e of inputs) {
+    if (e.kind === "char") {
+      const ch = normalizeChar(e.payload);
+      s.buffer = s.buffer + ch;
+    } else if (e.kind === "backspace") {
+      s.buffer = s.buffer.slice(0, -1);
+    } else if (e.kind === "submit") {
+      s = tryMatchByText(s, s.buffer);
+      s.buffer = "";
+    } else if (e.kind === "pointerSelect") {
+      s = tryMatchByPointer(s, e.payload.id);
+    }
+    if (s.lives <= 0) {
+      s.status = "over";
+      break;
+    }
+  }
+  return s;
+}
+
+function tryMatchByText(state: GameState, text: string): GameState {
+  if (!text) return state;
+  const s = { ...state };
+  const next = s.targetSequence[s.seqIndex];
+  // On choisit le mot visible le plus proche du bas qui correspond au texte
+  const candidate = [...s.words]
+    .filter((w) => w.text === text)
+    .sort((a, b) => b.y - a.y)[0];
+  if (!candidate) return s; // aucun mot avec ce texte
+
+  if (candidate.kind === "good" && candidate.text === next) {
+    // bon mot dans l'ordre
+    s.score += POINTS_PER_STEP;
+    s.seqIndex = (s.seqIndex + 1) % s.targetSequence.length;
+    s.words = s.words.filter((w) => w.id !== candidate.id);
+    return s;
+  } else {
+    // mauvais (faux ou bon mais hors ordre) ⇒ vie --
+    s.lives = Math.max(0, s.lives - 1);
+    // Retire le mot cliqué/tapé pour feedback immédiat
+    s.words = s.words.filter((w) => w.id !== candidate.id);
+    return s;
+  }
+}
+
+function tryMatchByPointer(state: GameState, id: string): GameState {
+  const s = { ...state };
+  const target = s.words.find((w) => w.id === id);
+  if (!target) return s;
+  const next = s.targetSequence[s.seqIndex];
+  if (target.kind === "good" && target.text === next) {
+    s.score += POINTS_PER_STEP;
+    s.seqIndex = (s.seqIndex + 1) % s.targetSequence.length;
+    s.words = s.words.filter((w) => w.id !== id);
+  } else {
+    s.lives = Math.max(0, s.lives - 1);
+    s.words = s.words.filter((w) => w.id !== id);
+  }
+  return s;
+}
+
+function shouldSpawn(s: GameState): boolean {
+  return s.timeMs - s.lastSpawnMs >= SPAWN_INTERVAL_MS + s.nextSpawnJitter;
+}
+
+export function spawnWord(prev: GameState): GameState {
+  const s = { ...prev };
+  s.lastSpawnMs = s.timeMs;
+  s.nextSpawnJitter = randInRange(-SPAWN_JITTER_MS, SPAWN_JITTER_MS);
+
+  const spawnGood = Math.random() < GOOD_PROBABILITY;
+  let text: string;
+  let kind: "good" | "bad";
+  if (spawnGood) {
+    // Biais pour faire apparaître le prochain mot attendu
+    const useNext = Math.random() < NEXT_TARGET_BIAS;
+    if (useNext) {
+      text = s.targetSequence[s.seqIndex];
+    } else {
+      // autre mot de la séquence (décoy)
+      const pool = s.targetSequence.filter((_, i) => i !== s.seqIndex);
+      text = pool[(Math.random() * pool.length) | 0] ?? s.targetSequence[s.seqIndex];
+    }
+    kind = "good";
+  } else {
+    text = BAD_WORDS[(Math.random() * BAD_WORDS.length) | 0];
+    kind = "bad";
+  }
+
+  const vy = BASE_FALL_PX_PER_S + randInRange(-FALL_SPEED_VARIANCE, FALL_SPEED_VARIANCE);
+  // X grossièrement aléatoire, marge 20..(width-120) (la largeur réelle est mesurée côté rendu pour le hit-test)
+  const x = clamp(20 + Math.random() * (GAME_WIDTH - 140), 10, GAME_WIDTH - 120);
+
+  const w: WordEntity = {
+    id: newId(),
+    text,
+    x,
+    y: -10, // start au-dessus du cadre
+    vy,
+    kind,
+  };
+  s.words = [...s.words, w];
+  return s;
+}
+
+export function stepFall(w: WordEntity, dtSec: number): WordEntity {
+  return { ...w, y: w.y + w.vy * dtSec };
+}
+
+function normalizeChar(c: string): string {
+  return c.normalize("NFKD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
+}
+
+function randInRange(min: number, max: number) {
+  return min + Math.random() * (max - min);
+}
+
+function clamp(v: number, a: number, b: number) {
+  return Math.max(a, Math.min(b, v));
+}

--- a/lib/game/types.ts
+++ b/lib/game/types.ts
@@ -1,0 +1,31 @@
+export type WordKind = "good" | "bad";
+
+export interface WordEntity {
+  id: string;
+  text: string;
+  x: number;
+  y: number;
+  vy: number; // px/s
+  kind: WordKind;
+}
+
+export type GameStatus = "running" | "over";
+
+export interface GameState {
+  timeMs: number;
+  score: number;
+  lives: number;
+  words: WordEntity[];
+  buffer: string;
+  status: GameStatus;
+  seqIndex: number; // index dans targetSequence (mot attendu)
+  targetSequence: string[];
+  lastSpawnMs: number;
+  nextSpawnJitter: number; // ms à ajouter à l'interval
+}
+
+export type InputEvent =
+  | { kind: "char"; payload: string }
+  | { kind: "backspace" }
+  | { kind: "submit" }
+  | { kind: "pointerSelect"; payload: { id: string } };

--- a/lib/render/canvas2d.ts
+++ b/lib/render/canvas2d.ts
@@ -1,0 +1,122 @@
+import { WORD_FONT, WORD_BOX_H, WORD_BOX_PAD } from "@/lib/game/config";
+import type { GameState, WordEntity } from "@/lib/game/types";
+
+export function drawScene(
+  ctx: CanvasRenderingContext2D,
+  state: GameState,
+  view: { width: number; height: number }
+) {
+  // Clear
+  ctx.save();
+  ctx.fillStyle = "#0e0f14";
+  ctx.fillRect(0, 0, view.width, view.height);
+  ctx.restore();
+
+  // Grid subtle
+  ctx.save();
+  ctx.globalAlpha = 0.06;
+  ctx.strokeStyle = "#ffffff";
+  for (let x = 0; x <= view.width; x += 40) {
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, view.height);
+    ctx.stroke();
+  }
+  for (let y = 0; y <= view.height; y += 40) {
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(view.width, y);
+    ctx.stroke();
+  }
+  ctx.restore();
+
+  // Words
+  ctx.font = WORD_FONT;
+  ctx.textBaseline = "top";
+  for (const w of state.words) {
+    drawWord(ctx, w, state);
+  }
+
+  // HUD overlay
+  drawHUD(ctx, state, view);
+}
+
+function drawWord(ctx: CanvasRenderingContext2D, w: WordEntity, s: GameState) {
+  const isNext = w.kind === "good" && w.text === s.targetSequence[s.seqIndex];
+  const textW = ctx.measureText(w.text).width;
+  // box
+  ctx.save();
+  ctx.fillStyle =
+    w.kind === "bad"
+      ? "rgba(255, 77, 109, 0.2)"
+      : isNext
+      ? "rgba(255, 215, 0, 0.22)"
+      : "rgba(56, 199, 125, 0.18)";
+  ctx.strokeStyle =
+    w.kind === "bad"
+      ? "rgba(255, 77, 109, 0.8)"
+      : isNext
+      ? "rgba(255, 215, 0, 0.85)"
+      : "rgba(56, 199, 125, 0.8)";
+  ctx.lineWidth = isNext ? 2 : 1;
+  roundRect(ctx, w.x - WORD_BOX_PAD, w.y - WORD_BOX_PAD, textW + WORD_BOX_PAD * 2, WORD_BOX_H, 6);
+  ctx.stroke();
+  ctx.fill();
+  // text
+  ctx.fillStyle = "#e6e7eb";
+  ctx.fillText(w.text, w.x, w.y);
+  ctx.restore();
+}
+
+function drawHUD(ctx: CanvasRenderingContext2D, s: GameState, view: { width: number; height: number }) {
+  ctx.save();
+  // Top bar
+  ctx.globalAlpha = 0.9;
+  ctx.fillStyle = "rgba(0,0,0,0.35)";
+  ctx.fillRect(0, 0, view.width, 36);
+  ctx.fillStyle = "#e6e7eb";
+  ctx.font = "14px system-ui";
+  ctx.textBaseline = "middle";
+  ctx.fillText(`Score: ${s.score}`, 10, 18);
+  ctx.fillText(`Vies: ${s.lives}`, 110, 18);
+  ctx.fillText(`Buffer: ${s.buffer}`, 200, 18);
+  // Sequence
+  let x = 360;
+  ctx.fillText("Séquence:", x, 18);
+  x += 80;
+  for (let i = 0; i < s.targetSequence.length; i++) {
+    const token = s.targetSequence[i];
+    const isNext = i === s.seqIndex;
+    const w = ctx.measureText(token).width;
+    ctx.fillStyle = isNext ? "#ffd700" : "#e6e7eb";
+    ctx.fillText(token, x, 18);
+    if (isNext) {
+      ctx.strokeStyle = "rgba(255,215,0,0.8)";
+      ctx.strokeRect(x - 4, 8, w + 8, 20);
+    }
+    x += w + 16;
+  }
+  // Game over overlay
+  if (s.status === "over") {
+    ctx.fillStyle = "rgba(0,0,0,0.55)";
+    ctx.fillRect(0, 0, view.width, view.height);
+    ctx.fillStyle = "#ffd700";
+    ctx.font = "28px system-ui";
+    ctx.textBaseline = "alphabetic";
+    const msg = "Game Over — appuie sur R pour recommencer";
+    const w = ctx.measureText(msg).width;
+    ctx.fillText(msg, (view.width - w) / 2, view.height / 2);
+  }
+  ctx.restore();
+}
+
+function roundRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number) {
+  const radius = Math.min(r, Math.abs(w) / 2, Math.abs(h) / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.arcTo(x + w, y, x + w, y + h, radius);
+  ctx.arcTo(x + w, y + h, x, y + h, radius);
+  ctx.arcTo(x, y + h, x, y, radius);
+  ctx.arcTo(x, y, x + w, y, radius);
+  ctx.closePath();
+}


### PR DESCRIPTION
## Summary
- add canvas-based Word Rain mini-game under /play
- implement game logic for word spawning, scoring and lives
- render words and HUD using Canvas2D

## Testing
- `node -v`
- `npm -v`
- `npm config set registry https://registry.npmjs.org/`
- `npm install`
- `npm test`
- `npm run build`
- `pnpm dev`


------
https://chatgpt.com/codex/tasks/task_e_68b3ee104334832f87c0ddae52de9757