### PR TITLE
Fix Word Rain lives loss on distractor words

### DIFF
--- a/lib/game/logic.ts
+++ b/lib/game/logic.ts
@@ -76,7 +76,11 @@ export function update(prev: GameState, dtMs: number, inputs: InputEvent[]): Gam
   let lost = 0;
   for (const w of s.words) {
     if (w.y > GAME_HEIGHT + 16) {
-      lost++;
+      // Only penalize the player when a "good" word is missed.
+      if (w.kind === "good") {
+        lost++;
+      }
+      // In all cases, drop the word once it exits the screen.
     } else {
       kept.push(w);
     }


### PR DESCRIPTION
## Summary
- avoid decrementing lives when non-target words fall off screen in the Word Rain game

## Testing
- `node -v`
- `npm -v`
- `npm config set registry https://registry.npmjs.org/`
- `npm install`
- `npm test`
- `npm run build`
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_68b4ac606898832f937062668b9007eb