### PR TITLE
feat: rotate random color sequences

### DIFF
--- a/lib/game/types.ts
+++ b/lib/game/types.ts
@@ -20,6 +20,7 @@ export interface GameState {
   status: GameStatus;
   seqIndex: number; // index dans targetSequence (mot attendu)
   targetSequence: string[];
+  sequenceQueue: string[][]; // séquences restantes à jouer
   lastSpawnMs: number;
   nextSpawnJitter: number; // ms à ajouter à l'interval
 }

--- a/lib/render/canvas2d.ts
+++ b/lib/render/canvas2d.ts
@@ -96,17 +96,7 @@ function drawHUD(ctx: CanvasRenderingContext2D, s: GameState, view: { width: num
     }
     x += w + 16;
   }
-  // Game over overlay
-  if (s.status === "over") {
-    ctx.fillStyle = "rgba(0,0,0,0.55)";
-    ctx.fillRect(0, 0, view.width, view.height);
-    ctx.fillStyle = "#ffd700";
-    ctx.font = "28px system-ui";
-    ctx.textBaseline = "alphabetic";
-    const msg = "Game Over — appuie sur R pour recommencer";
-    const w = ctx.measureText(msg).width;
-    ctx.fillText(msg, (view.width - w) / 2, view.height / 2);
-  }
+  // Game over overlay handled by React component
   ctx.restore();
 }
 


### PR DESCRIPTION
## Summary
- track next expected word and only penalize when that word is missed
- shuffle through predefined color sequences, loading a new one once the current sequence is completed
- display centered restart button on game over instead of relying on the R key

## Testing
- `node -v`
- `npm -v`
- `npm config set registry https://registry.npmjs.org/`
- `npm install`
- `npm test`
- `npm run build`
- `pnpm dev`


------
https://chatgpt.com/codex/tasks/task_e_68b5f866db00832fa4305878195b6196