### PR TITLE
feat: externalize color sequences

### DIFF
--- a/components/GameCanvas.tsx
+++ b/components/GameCanvas.tsx
@@ -84,6 +84,9 @@ export default function GameCanvas() {
       // Accept single visible characters (letters incl. accents, numbers)
       if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
         inputsRef.current.push({ kind: "char", payload: e.key });
+        if (e.key === " ") {
+          e.preventDefault();
+        }
       }
     };
     window.addEventListener("keydown", onKeyDown);

--- a/lib/game/logic.ts
+++ b/lib/game/logic.ts
@@ -10,26 +10,9 @@ import {
   GAME_HEIGHT,
   GAME_WIDTH,
 } from "./config";
+import { SEQUENCES, BAD_WORDS } from "./sequences";
 import type { GameState, InputEvent, WordEntity } from "./types";
 export type { GameState, InputEvent } from "./types";
-
-// Séquences possibles (dans l'ordre attendu)
-const SEQUENCES = [
-  ["rouge", "vert", "bleu"],
-  ["rose", "jaune", "vert"],
-  ["gris", "bleu", "violet"],
-];
-// Mots "faux" (distracteurs)
-const BAD_WORDS = [
-  "noir",
-  "blanc",
-  "orange",
-  "marron",
-  "cyan",
-  "magenta",
-  "sable",
-  "olive",
-];
 
 let _id = 0;
 const newId = () => String(++_id);

--- a/lib/game/sequences.ts
+++ b/lib/game/sequences.ts
@@ -1,0 +1,17 @@
+export const SEQUENCES = [
+  ["rouge", "vert", "bleu"],
+  ["rose", "jaune", "vert"],
+  ["gris", "bleu", "violet"],
+  ["bleu roi", "bleu marine", "bleu ciel"],
+];
+
+export const BAD_WORDS = [
+  "noir",
+  "blanc",
+  "orange",
+  "marron",
+  "cyan",
+  "magenta",
+  "sable",
+  "olive",
+];


### PR DESCRIPTION
## Summary
- externalize color sequences and bad word list to dedicated module
- allow multi-word colors in sequences
- prevent default scrolling so spacebar works when typing colors

## Testing
- `node -v`
- `npm -v`
- `npm config set registry https://registry.npmjs.org/`
- `npm install`
- `npm test`
- `npm run build`
- `pnpm dev`


------
https://chatgpt.com/codex/tasks/task_e_68b5fdea5d68832f8d1906c9f7224ff6